### PR TITLE
Pull in configurable registry client

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/rs/zerolog v1.30.0
 	github.com/spf13/cobra v1.7.0
 	github.com/tessellated-io/healthchecks v0.0.2
-	github.com/tessellated-io/pickaxe v1.1.5
+	github.com/tessellated-io/pickaxe v1.1.6
 	github.com/tessellated-io/router v0.0.5
 	gopkg.in/yaml.v2 v2.4.0
 )

--- a/go.sum
+++ b/go.sum
@@ -639,8 +639,8 @@ github.com/tendermint/go-amino v0.16.0 h1:GyhmgQKvqF82e2oZeuMSp9JTN0N09emoSZlb2l
 github.com/tendermint/go-amino v0.16.0/go.mod h1:TQU0M1i/ImAo+tYpZi73AU3V/dKeCoMC9Sphe2ZwGME=
 github.com/tessellated-io/healthchecks v0.0.2 h1:u/eGeg0rlb3tGOz0GXhHHPE5fgoETWnbR9NG5KdMHJI=
 github.com/tessellated-io/healthchecks v0.0.2/go.mod h1:SNLJVFCD2Z9IFRYNiF7f4hoJ4+RsjHgrK7YvKCixfdI=
-github.com/tessellated-io/pickaxe v1.1.5 h1:TjLx58NFCROyCUQq/jNosvhQaUmpBmtwhkYGirSCPLU=
-github.com/tessellated-io/pickaxe v1.1.5/go.mod h1:G6FMTiWB8rLG4YH0THu2t2tZIMUC2Rykl22JotEIgLM=
+github.com/tessellated-io/pickaxe v1.1.6 h1:L/9GhwnIdjLekOldkA8mzy9ak8TC27fohxsZZBY4BTY=
+github.com/tessellated-io/pickaxe v1.1.6/go.mod h1:G6FMTiWB8rLG4YH0THu2t2tZIMUC2Rykl22JotEIgLM=
 github.com/tessellated-io/router v0.0.5 h1:t6XXH4neABYljW4Nrf1u+orYXf1VUg249BwWMdbD3Bc=
 github.com/tessellated-io/router v0.0.5/go.mod h1:Oj5Zw+/B5IwoL1ocuTsySz/1ZWEIxln50oHt0YbSjlQ=
 github.com/tidwall/btree v1.6.0 h1:LDZfKfQIBHGHWSwckhXI0RPSXzlo+KYdjK7FWSqOzzg=

--- a/restake/configuration_loader.go
+++ b/restake/configuration_loader.go
@@ -26,6 +26,7 @@ type Configuration struct {
 	RunIntervalSeconds       uint     `yaml:"run_interval_seconds" comment:"How many seconds to wait in between restake runs"`
 	BatchSize                uint     `yaml:"batch_size" comment:"What size batches of transactions should be sent in"`
 	ChainRegistryBaseUrl     string   `yaml:"chain_registry_base_url" comment:"The base url for the chain registry"`
+	ValidatorRegistryBaseUrl string   `yaml:"validator_registry_base_url" comment:"The base url for the validator registry"`
 }
 
 func (c *Configuration) VersionedMemo(version string) string {

--- a/restake/restake_manager.go
+++ b/restake/restake_manager.go
@@ -118,7 +118,7 @@ func (rm *RestakeManager) runOnce(ctx context.Context, localConfiguration *Confi
 	rm.logger.Debug().Msg("starting core restake loop")
 
 	// Retryable chain registry client
-	rawChainClient := chainregistry.NewChainRegistryClient(rm.logger, localConfiguration.ChainRegistryBaseUrl)
+	rawChainClient := chainregistry.NewChainRegistryClient(rm.logger, localConfiguration.ChainRegistryBaseUrl, localConfiguration.ValidatorRegistryBaseUrl)
 	chainRegistryClient, err := chainregistry.NewRetryableChainRegistryClient(
 		localConfiguration.NetworkRetryAttempts,
 		localConfiguration.NetworkRetryDelay(),


### PR DESCRIPTION
- Registry clients have been flaky because the public APIs seem flaky
- Public APIs also seem to be somewhat non-standard in responses and url format
- Instead, we build/deploy [Planetarium](https://github.com/tessellated-io/planetarium)
- Migrate to a version of dependencies that lets us use that service